### PR TITLE
Exposing void Settings::ReadSettings() to Papyrus.

### DIFF
--- a/papyrus/source/SimpleBeheading.psc
+++ b/papyrus/source/SimpleBeheading.psc
@@ -1,0 +1,3 @@
+ScriptName SimpleBeheading Hidden
+
+Function ReadSettings() Global Native

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,5 +1,6 @@
 #include "hooks.h"
 #include "dataHandler.h"
+#include "papyrus.h"
 
 void MessageHandler(SKSE::MessagingInterface::Message* a_msg)
 {
@@ -14,4 +15,5 @@ void Load()
 {
 	SKSE::GetMessagingInterface()->RegisterListener("SKSE", MessageHandler);
 	hitEventHook::InstallHook();
+	SKSE::GetPapyrusInterface()->Register(papyrus::RegisterFunctions);
 }

--- a/src/papyrus.h
+++ b/src/papyrus.h
@@ -1,0 +1,24 @@
+
+namespace papyrus
+{
+	inline unsigned int functions_counter = 0;
+
+	static void ReadSettings(RE::StaticFunctionTag*)
+	{
+		Settings::ReadSettings();
+	}
+
+	/**
+	 * \brief Register functions for Papyrus scripts.
+	 * \param a_virtual_machine   - Papyrus virtual machine.
+	 * \return                  - True, if everything went fine.
+	 */
+	inline bool RegisterFunctions(RE::BSScript::IVirtualMachine* a_virtual_machine)
+	{
+		a_virtual_machine->RegisterFunction("ReadSettings", Plugin::NAME, ReadSettings);
+		functions_counter++;
+
+		logger::info("Registered {} Papyrus function/s.", functions_counter);
+		return true;
+	}
+}


### PR DESCRIPTION
PSC file can be ignored, since only MCM will be using it, and I can include it in MCM patch.